### PR TITLE
remove i10n locales from DatePicker

### DIFF
--- a/src/DatePicker/createCalendar.js
+++ b/src/DatePicker/createCalendar.js
@@ -1,5 +1,4 @@
 import flatpickr from "flatpickr";
-import l10n from "flatpickr/dist/l10n/index.js";
 import rangePlugin from "flatpickr/dist/plugins/rangePlugin";
 
 function updateClasses(instance) {


### PR DESCRIPTION
This saves 41972 bytes from the total build bundle size. Locales can be optionally added by importing in the app the specific locale (or all of them), according to the flatpickr documentation: https://flatpickr.js.org/localization/